### PR TITLE
Fix URL for hatcloud.rb

### DIFF
--- a/hatcloud.rb
+++ b/hatcloud.rb
@@ -58,7 +58,7 @@ if options[:bypass].nil?
     puts "Insert URL -b or --byp"
 else
 	option = options[:bypass]
-	payload = URI ("http://www.crimeflare.us:82/cfs.html#box")
+	payload = URI ("http://www.crimeflare.us:82/cgi-bin/cfsearch.cgi")
 	request = Net::HTTP.post_form(payload, 'cfS' => options[:bypass])
 
 	response =  request.body


### PR DESCRIPTION
It seems like http://www.crimeflare.us:82/cgi-bin/cfsearch.cgi is the correct URL.